### PR TITLE
Update repository URL

### DIFF
--- a/activity/activity.info
+++ b/activity/activity.info
@@ -7,5 +7,5 @@ activity_version = 21
 show_launcher = yes
 license = GPLv3+
 summary = Decode the world and help the world decode you. Use this translator for access and learn about many different languages!
-repository = git@github.com:godiard/words-activity.git
+repository = https://github.com/sugarlabs/words-activity
 max_participants = 1


### PR DESCRIPTION
- use HTTPS transport, fixes `git clone` on systems that don't have an SSH key for github.com,
- follow recent redirect from `godiard/words-activity` to `sugarlabs/`
