### PR TITLE
Fix Suggestions displaying bytes like string instead of real string i…

### DIFF
--- a/dictdlib.py
+++ b/dictdlib.py
@@ -346,7 +346,13 @@ class DictDB:
                 'select word from definitions where word like ?',
                 (memoryview('%{}%'.format(word).encode()), ))
             for row in rows:
-                suggestions.append(str(row[0]))
+                if type(row[0]) is bytes:
+                    suggestions.append(row[0].decode('utf-8'))
+                elif type(row[0]) is str:
+                    suggestions.append(row[0])
+                else:
+                    raise Exception('ERROR: get_suggestions received a non-string like object')
+                    # Errors should not be passed silently. FIXME
         else:
             for key in self.getdeflist():
                 if word in key:


### PR DESCRIPTION
I created an issue, but I ended up fixing it :wink: :stuck_out_tongue_winking_eye: 

**BEFORE**
![image](https://user-images.githubusercontent.com/48695438/71609308-66539b00-2b98-11ea-80cd-bd20ab1adc4d.png)

**AFTER** 
![image](https://user-images.githubusercontent.com/48695438/71609291-4de38080-2b98-11ea-807d-aeb8fec66234.png)

See #23 for screenshots
Fixes #23 , sorry for creating that issue.
This error is only applicalble to Hindi, Deutch and Arabic. I don't know why. 
Probably because Spanih, French and English depends on `dictdmodel.py`, but I don't know. Consider rechecking the python3 port